### PR TITLE
remove cruft

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -4,13 +4,9 @@
   tasks:
     - pause:
         seconds: 30
-    - name: install system updates for centos systems
-      yum: name=* state=present update_cache=yes
-      when: ansible_distribution == "CentOS"
 
     - name: install system updates for ubuntu systems
       apt: upgrade=dist update_cache=yes
-      when: ansible_distribution == "Ubuntu"
 
     - name: install packages
       package:
@@ -24,7 +20,6 @@
       shell: "[ -x /snap ] || yum install -y epel-release snapd && systemctl enable --now snapd.socket && ln -s /var/lib/snapd/snap /snap || echo ''"
       register: snap_installed
 
-    # awscli and amazon-ssm-agent are on aws linux2 by default
     - name: Install awscli and amazon-ssm-agent
       snap:
         name:


### PR DESCRIPTION
Initially we had planned to use one ansible playbook for multiple
distributions however this repo is specifically for ubuntu so
now we are removing the cruft that's not needed.