### PR TITLE
[SC-95] fix device name in packer template

### DIFF
--- a/src/template.json
+++ b/src/template.json
@@ -8,7 +8,7 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "/dev/xvda",
+          "device_name": "/dev/sda1",
           "volume_size": "{{user `VolumeSize`}}",
           "volume_type": "gp2"
         }


### PR DESCRIPTION
device_name "/dev/xvda" is the correct setting for aws linux AMIs.
setting it to this value for ubuntu will result in creation of two
snapshots for the image.  We really only need one root volume,
the fix is to set it to "/dev/sda1", this will create the AMI
will only one associated snapshot volume.