### PR TITLE
[IT-837] Add AWS CFN helper tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you would like to test building an AMI run:
 ```
 cd src
 export IMAGE_NAME=<repo name>-test
-packer build -var AwsProfile=my-aws-account -var AwsRegion=us-east-1 -var IMAGE_NAME=${IMAGE_NAME} template.json
+packer build -var AwsProfile=my-aws-account -var AwsRegion=us-east-1 -var ImageName=${IMAGE_NAME} template.json
 ```
 
 Packer will do the following:

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -14,6 +14,9 @@
           - "ntpdate"
           - "curl"
           - "jq"
+          - "python2.7-minimal"    # for legacy apps
+          - "python-pip"
+          - "python-setuptools"
           - "python3-pip"
         state: present
 
@@ -49,3 +52,13 @@
         name:
           - awsmfa==0.2.9
         executable: pip3
+
+    - name: Make aws apps directory
+      file:
+        path: /opt/aws/bin
+        state: directory
+        mode: '0755'
+
+    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-helper-scripts-reference.html (requires python2.7)
+    - name: install aws cfn helper scripts
+      shell: "sudo /usr/bin/python2.7 /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz"

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -32,6 +32,12 @@
         classic: yes
       when: "not snap_installed.stdout"
 
+    - name: Create a symbolic link
+      file:
+        src: /snap/bin/aws
+        dest: /usr/bin/aws
+        state: link
+
     - name: Update time
       shell: "ntpdate -u pool.ntp.org"
 


### PR DESCRIPTION
Install AWS cloudformation helper scripts[1] to ubuntu AMI.  It's used
for AWS::CloudFormation::Init[2].

We pre-install the tools on the AMI so we won't need to install it
in our cloudformation provisioner templates.

[1] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-helper-scripts-reference.html
[2] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-init.html