### PR TITLE
[IT-837] install jq

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -13,6 +13,7 @@
         name:
           - "ntpdate"
           - "curl"
+          - "jq"
           - "python3-pip"
         state: present
 


### PR DESCRIPTION
add jq[1] to the AMI because it is an essential tool for working
with AWS::CloudFormation::Init[2]

[1] https://stedolan.github.io/jq/
[2] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-init.html