### PR TITLE
Install aptdaemon so that aptdcon can be used by dependent AMIs

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -18,6 +18,7 @@
           - "python-pip"
           - "python-setuptools"
           - "python3-pip"
+          - "aptdaemon"
         state: present
 
     - name: Prep snap classic


### PR DESCRIPTION
Install [aptdaemon](https://launchpad.net/aptdaemon). Inspired by [this AskUbuntu issue](https://askubuntu.com/questions/132059/how-to-make-a-package-manager-wait-if-another-instance-of-apt-is-running): "You can use the aptdcon command to queue up package manager tasks by communicating with aptdaemon instead of using apt-get directly."
