### PR TITLE
Set nice ubuntu login shell

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -84,6 +84,9 @@
             . ~/.profile
           fi
 
+    - name: create ssm-user homedir if not exist
+      file: path=/home/ssm-user state=directory
+
     - name: set ssm-user shell redirect
       copy:
         dest: /home/ssm-user/.profile

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -84,14 +84,10 @@
             . ~/.profile
           fi
 
-    - name: create ssm-user homedir if not exist
-      file: path=/home/ssm-user state=directory
-
-    - name: set ssm-user shell redirect
+    - name: set systemwide profile shell redirect
       copy:
-        dest: /home/ssm-user/.profile
+        dest: /etc/skel/.profile
         content: |
           if [ "${0}" = "sh" ]; then
             exec bash
           fi
-          cd

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -69,3 +69,26 @@
     # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-helper-scripts-reference.html (requires python2.7)
     - name: install aws cfn helper scripts
       shell: "sudo /usr/bin/python2.7 /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz"
+
+    - name: make default environment for users
+      lineinfile:
+        path: /etc/systemd/system.conf
+        line: DefaultEnvironment="ENV=/etc/profile"
+        state: present
+
+    - name: set systemwide profile source
+      copy:
+        dest: /etc/profile.d/sh.local
+        content: |
+          if [ -r ~/.profile ]; then
+            . ~/.profile
+          fi
+
+    - name: set ssm-user shell redirect
+      copy:
+        dest: /home/ssm-user/.profile
+        content: |
+          if [ "${0}" = "sh" ]; then
+            exec bash
+          fi
+          cd

--- a/src/template.json
+++ b/src/template.json
@@ -57,7 +57,7 @@
     "OwnerEmail": "khai.do@sagebase.org",
     "Project": "Infrastructure",
     "SnapshotGroups": "all",
-    "SourceImage": "ami-07ebfd5b3428b6f4d",
+    "SourceImage": "ami-06ffade19910cbfc0",
     "SshUsername": "ubuntu",
     "VolumeSize": "8"
   }

--- a/src/template.json
+++ b/src/template.json
@@ -57,7 +57,7 @@
     "OwnerEmail": "khai.do@sagebase.org",
     "Project": "Infrastructure",
     "SnapshotGroups": "all",
-    "SourceImage": "ami-06ffade19910cbfc0",
+    "SourceImage": "ami-07ebfd5b3428b6f4d",
     "SshUsername": "ubuntu",
     "VolumeSize": "8"
   }


### PR DESCRIPTION
This sets up a nice ssm-user login, should be durable between os updates, and won't get in the way of other types of login.

This does *not* work in the same way as configuring post-boot on the image, and I'm not sure why that it...

Hold off on approving/merging