### PR TITLE
Fix relocation error

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -5,10 +5,10 @@
     - pause:
         seconds: 30
 
-    - name: install system updates for ubuntu systems
+    - name: Install system updates for ubuntu systems
       apt: upgrade=dist update_cache=yes
 
-    - name: install packages
+    - name: Install packages
       package:
         name:
           - "ntpdate"
@@ -36,18 +36,24 @@
         link: /usr/bin/pip
         path: /usr/bin/pip3
 
-    - name: Install awscli and amazon-ssm-agent
-      snap:
-        name:
-          - aws-cli
-          - amazon-ssm-agent
-        classic: yes
+    - name: Install aws-cli | Install unzip
+      apt:
+        name: unzip
 
-    - name: Create a symbolic link
-      file:
-        src: /snap/bin/aws
-        dest: /usr/bin/aws
-        state: link
+    - name: Install aws-cli | Download awscli.zip
+      get_url:
+        url: https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
+        dest: /tmp/awscliv2.zip
+        force: yes
+
+    - name: Install aws-cli | Unarchive awscli.zip
+      unarchive:
+        src: /tmp/awscliv2.zip
+        dest: /tmp
+        remote_src: yes
+
+    - name: Install aws-cli | Run installer
+      shell: "sh /tmp/aws/install -i /usr/local/aws-cli -b /usr/bin"
 
     - name: Make aws apps directory
       file:
@@ -57,4 +63,4 @@
 
     # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-helper-scripts-reference.html (requires python2.7)
     - name: install aws cfn helper scripts
-      shell: "sudo /usr/bin/python2.7 /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz"
+      shell: "/usr/bin/python2.7 /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz"

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -21,24 +21,6 @@
           - "aptdaemon"
         state: present
 
-    - name: Prep snap classic
-      shell: "[ -x /snap ] || yum install -y epel-release snapd && systemctl enable --now snapd.socket && ln -s /var/lib/snapd/snap /snap || echo ''"
-      register: snap_installed
-
-    - name: Install awscli and amazon-ssm-agent
-      snap:
-        name:
-          - aws-cli
-          - amazon-ssm-agent
-        classic: yes
-      when: "not snap_installed.stdout"
-
-    - name: Create a symbolic link
-      file:
-        src: /snap/bin/aws
-        dest: /usr/bin/aws
-        state: link
-
     - name: Update time
       shell: "ntpdate -u pool.ntp.org"
 
@@ -54,11 +36,18 @@
         link: /usr/bin/pip
         path: /usr/bin/pip3
 
-    - name: install awsmfa
-      pip:
+    - name: Install awscli and amazon-ssm-agent
+      snap:
         name:
-          - awsmfa==0.2.9
-        executable: pip3
+          - aws-cli
+          - amazon-ssm-agent
+        classic: yes
+
+    - name: Create a symbolic link
+      file:
+        src: /snap/bin/aws
+        dest: /usr/bin/aws
+        state: link
 
     - name: Make aws apps directory
       file:


### PR DESCRIPTION
Fixes [relocation error bug](https://sagebionetworks.jira.com/browse/SC-182).

~Move python3, pip3 default steps ahead of snap installs to fix relocation error in SC-182~
Revised original fix for the following reasons:
1. amazon-ssm-agent does not need to be installed -- it is already present in the SourceImage.
2. Relying on the aws-cli wasn't a good idea -- it hasn't been updated in nearly two years

The install of aws-cli now installs AWS CLI version 2, as recommended. It also follows the recommended pattern for the CLI install as directed [here](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html). The alternative was to use pip to do the install, which could have been achieved in one playbook step. However, I believe the method I chose is preferable as it is a bundled installer that "has no dependencies on other Python packages. It has a self-contained, embedded copy of Python included in the installer."

awsmfa has also been removed, since we have moved away from using IAM user accounts.

The test build of this base image has been used in a test build of packer-rstudio. The build completes successfully, ConnectionURI works, and the cfn-init.log looks healthy.