### PR TITLE
Include docker binaries in base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Overview
-Project to build a base ubuntu image and deploy it to AWS
+Project to build a base ubuntu image for Sage Bionetworks science use and deploy it to AWS.
+The image is based on the latest Ubuntu Bionic release available at the point of build and also
+includes the following:
+- Python3 and supporting libs
+- Docker binaries
+- AWS CLI client
 
 ## Workflow
 The workflow to provision AWS AMI is done using pull requests.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Travis runs packer which temporarily deploys an EC2 to create an AMI.
 ## Continuous Integration
 We have configured Travis to deploy cloudformation template updates.
 
+## Possible Upcoming changes
+Replace AWS CLI client binaries with docker container version and make system-wide shell alias
+
 ## Issues
 * https://sagebionetworks.jira.com/projects/IT
 

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -36,6 +36,27 @@
         link: /usr/bin/pip
         path: /usr/bin/pip3
 
+    - name: Add Docker GPG key
+      apt_key: url=https://download.docker.com/linux/ubuntu/gpg
+
+    - name: install pre-docker packages  # this must be installed before adding docker repository
+      shell: "yes | aptdcon --hide-terminal --install 'apt-transport-https'"
+
+    - name: Add Docker APT repository
+      apt_repository:
+        repo: deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ansible_distribution_release}} stable
+        update_cache: yes
+
+    - name: install packages
+      shell: "yes | aptdcon --hide-terminal --install 'docker-ce docker-ce-cli containerd.io'"
+
+    - name: Docker post-install
+      shell: |
+        if [ -z $(getent group docker) ]; then
+          groupadd docker
+        fi
+        gpasswd -a {{ lookup('env','SSH_USERNAME') }} docker
+
     - name: Install aws-cli | Install unzip
       apt:
         name: unzip

--- a/src/template.json
+++ b/src/template.json
@@ -57,7 +57,7 @@
     "OwnerEmail": "khai.do@sagebase.org",
     "Project": "Infrastructure",
     "SnapshotGroups": "all",
-    "SourceImage": "ami-07ebfd5b3428b6f4d",
+    "SourceImage": "ami-0d0032af1da6905c7",
     "SshUsername": "ubuntu",
     "VolumeSize": "8"
   }


### PR DESCRIPTION
This change is the move the docker install to the base image. This makes docker available in general across all downstream images and will allow users to follow the workflow of pushing and pulling from the Synapse container registry in any of the environments.

Some ideas for further changes:
 - Install AWS CLI through docker rather than from tarballs
 - Make this platform independent by building on different sources AMIs

Follow on commit references Ubuntu Bionic AMI-ID `ami-0d0032af1da6905c7` from https://cloud-images.ubuntu.com/locator/ec2/

Depends on https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-bionic/pull/27

Passes pre-commit