### PR TITLE
Add SSH_USERNAME var to ansible config

### DIFF
--- a/src/template.json
+++ b/src/template.json
@@ -41,7 +41,7 @@
     {
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='-o IdentitiesOnly=yes'",
-	"SSH_USERNAME={{user `SshUsername`}}"
+        "SSH_USERNAME={{user `SshUsername`}}"
       ],
       "extra_arguments": [
         "-v"

--- a/src/template.json
+++ b/src/template.json
@@ -40,7 +40,8 @@
   "provisioners": [
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='-o IdentitiesOnly=yes'"
+        "ANSIBLE_SSH_ARGS='-o IdentitiesOnly=yes'",
+	"SSH_USERNAME={{user `SshUsername`}}"
       ],
       "extra_arguments": [
         "-v"


### PR DESCRIPTION
The ansible env needs a default user to add to the docker users group. We've been using the default ubuntu user for this, and we've been doing it in a way that requires ansible to build on a Ubuntu host (or at least not in a weird container env. like my test machine).

This adds the variable to the ansible config to make the build work on travis.